### PR TITLE
Refactored to remove usage of C# 7.0 feature ValueTuple 

### DIFF
--- a/DotNetTracking.Tests/TestHelper.cs
+++ b/DotNetTracking.Tests/TestHelper.cs
@@ -10,7 +10,8 @@ namespace Haukcode.DotNetTracking.Tests
     {
         private static string ChangeCheckDigit(string input)
         {
-            var (seq, last) = TrackingType.GetSequence(input);
+            char last;
+            var seq = TrackingType.GetSequence(input, out last);
             int.TryParse(last.ToString(), out int checkDigit);
             char newCheckDigit = (checkDigit <= 2 ? checkDigit + 3 : checkDigit - 3).ToString()[0];
 

--- a/DotNetTracking/Carriers/DHL.cs
+++ b/DotNetTracking/Carriers/DHL.cs
@@ -18,7 +18,8 @@ namespace Haukcode.DotNetTracking
         protected static bool IsValidCheckSum(string input)
         {
             // Standard mod 7 check
-            var (sequence, checkDigit) = GetDigits(input);
+            int checkDigit;
+            var sequence = GetDigits(input, out checkDigit);
 
             long value = long.Parse(string.Join("", sequence));
 

--- a/DotNetTracking/Carriers/FedEx.cs
+++ b/DotNetTracking/Carriers/FedEx.cs
@@ -37,7 +37,8 @@ namespace Haukcode.DotNetTracking
 
         protected static bool IsValidCheckSum(string input)
         {
-            var (sequence, checkDigit) = GetDigits(input);
+            int checkDigit;
+            var sequence = GetDigits(input, out checkDigit);
 
             int total = sequence.Reverse().Select((x, i) => (i % 2 == 0) ? x * 3 : x).Sum();
 

--- a/DotNetTracking/Carriers/OnTrac.cs
+++ b/DotNetTracking/Carriers/OnTrac.cs
@@ -28,7 +28,8 @@ namespace Haukcode.DotNetTracking
             if (!Regex.Match(input, VerifyPattern).Success)
                 return false;
 
-            var (sequence, checkDigit) = GetSequence(input);
+            char checkDigit;
+            var sequence = GetSequence(input, out checkDigit);
 
             // Same check as for UPS
 

--- a/DotNetTracking/Carriers/UPS.cs
+++ b/DotNetTracking/Carriers/UPS.cs
@@ -134,7 +134,8 @@ namespace Haukcode.DotNetTracking
             if (!Regex.Match(input, VerifyPattern).Success)
                 return false;
 
-            var (sequence, checkDigit) = GetSequence(input);
+            char checkDigit;
+            var sequence = GetSequence(input, out checkDigit);
 
             int total = sequence
                 .Skip(2)

--- a/DotNetTracking/Carriers/USPS.cs
+++ b/DotNetTracking/Carriers/USPS.cs
@@ -33,7 +33,8 @@ namespace Haukcode.DotNetTracking
 
         protected static bool IsValidCheckSum(string input)
         {
-            var (sequence, checkDigit) = GetDigits(input);
+            int checkDigit;
+            var sequence = GetDigits(input, out checkDigit);
 
             int total = sequence.Reverse().Select((x, i) => (i % 2 == 0) ? x * 3 : x).Sum();
 

--- a/DotNetTracking/Carriers/USPS13.cs
+++ b/DotNetTracking/Carriers/USPS13.cs
@@ -28,7 +28,8 @@ namespace Haukcode.DotNetTracking
             if (!numericSequence.Success)
                 return false;
 
-            var (sequence, checkDigit) = GetDigits(numericSequence.Value);
+            int checkDigit;
+            var sequence = GetDigits(numericSequence.Value, out checkDigit);
 
             var data = sequence.Zip(new int[] { 8, 6, 4, 2, 3, 5, 9, 7 }, (a, b) => a * b);
             int total = data.Sum();

--- a/DotNetTracking/TrackingType.cs
+++ b/DotNetTracking/TrackingType.cs
@@ -52,18 +52,20 @@ namespace Haukcode.DotNetTracking
             }
         }
 
-        public static (IEnumerable<int> Sequence, int CheckDigit) GetDigits(string input)
+        public static IEnumerable<int> GetDigits(string input, out int CheckDigit)
         {
             var all = input.ToCharArray().Select(x => int.Parse(x.ToString()));
+            CheckDigit = all.Last();
 
-            return (WithoutLast(all), all.Last());
+            return WithoutLast(all);
         }
 
-        public static (IEnumerable<char> Sequence, char CheckDigit) GetSequence(string input)
+        public static IEnumerable<char> GetSequence(string input, out char CheckDigit)
         {
             var all = input.ToCharArray();
+            CheckDigit = all.Last();
 
-            return (WithoutLast(all), all.Last());
+            return WithoutLast(all);
         }
 
         public static TrackingType[] GetMatches(string input)


### PR DESCRIPTION
So that library can be used with .NET Framework v4.5 / v4.6.

This should fix Issue #2 

My client is going to test on their deployment server; I won't know for sure until then that this change is adequate.
That will be a test against v4.6.1. I'm fairly certain that it will be compatible with v4.5 as well, but I haven't tested that.
